### PR TITLE
fix: disable CSS compression in astro-compress

### DIFF
--- a/astro/astro.config.ts
+++ b/astro/astro.config.ts
@@ -139,7 +139,7 @@ export default defineConfig({
     ),
 
     compress({
-      CSS: true,
+      CSS: false,
       HTML: {
         'html-minifier-terser': {
           removeAttributeQuotes: false,


### PR DESCRIPTION
astro-compress uses an older CSS minifier that does not support Tailwind CSS v4's modern media query range syntax (e.g. width>=48rem) and silently strips out all responsive classes.
Disabled CSS compression in astro-compress since Vite's native CSS minifier already correctly handles it.